### PR TITLE
bugfix tiff tag bits per sample, byte_depth assignment

### DIFF
--- a/python/ndstorage/ndtiff_file.py
+++ b/python/ndstorage/ndtiff_file.py
@@ -172,7 +172,16 @@ class SingleNDTiffWriter:
         if self.file.tell() % 2 == 1:
             self.file.seek(self.file.tell() + 1)  # Make IFD start on word
 
-        byte_depth = 1 if isinstance(pixels, bytearray) else 2
+        if isinstance(pixels, bytearray):
+            byte_depth = 1
+        # if the pixel object is a numpy array, it is type of <class 'numpy.ndarray'>
+        # when using np_array.tobytes it is <class 'bytes'>
+        # therefore taking the the bit_depth information "pixels.dtype" into account
+        elif bit_depth == 8:
+            byte_depth = 1
+        else:
+            byte_depth = 2
+
         bytes_per_image_pixels = self._bytes_per_image_pixels(pixels, rgb)
         num_entries = 13
 


### PR DESCRIPTION
For 8bit gray scale numpy arrays the tiff tag entry "BITS_PER_SAMPLE = 258" gets 2*8 instead of 1*8 bits. (controlled by the byte_depth variable). Therefore the tiff files are opened wrong in a non ndtiff, standard tiff reader.