### PR TITLE
Optimize reader

### DIFF
--- a/python/ndstorage/ndtiff_dataset.py
+++ b/python/ndstorage/ndtiff_dataset.py
@@ -258,7 +258,11 @@ class NDTiffDataset(NDStorageBase, WritableNDStorageAPI):
                 self.index[frozenset(image_coordinates.items())] = index_entry
 
             if index_entry.filename not in self._readers_by_filename:
-                new_reader = SingleNDTiffReader(os.path.join(self.path, index_entry.filename), file_io=self.file_io)
+                # prevent new reader object when writing:
+                if self._writable and self.current_writer.filename.split(os.sep)[-1] == index_entry.filename:
+                    new_reader = self.current_writer.reader
+                else:
+                    new_reader = SingleNDTiffReader(os.path.join(self.path, index_entry.filename), file_io=self.file_io)
                 self._readers_by_filename[index_entry.filename] = new_reader
                 # Should be the same on every file so resetting them is fine
                 self.major_version, self.minor_version = new_reader.major_version, new_reader.minor_version

--- a/python/ndstorage/ndtiff_file.py
+++ b/python/ndstorage/ndtiff_file.py
@@ -5,6 +5,7 @@ import os
 import time
 import struct
 import warnings
+import mmap
 from collections import OrderedDict
 from io import BytesIO
 from .file_io import NDTiffFileIO, BUILTIN_FILE_IO
@@ -314,6 +315,8 @@ class SingleNDTiffReader:
         self.file_io = file_io
         self.tiff_path = tiff_path
         self.file = self.file_io.open(tiff_path, "rb")
+        # mmap speeds up random access
+        self.mmap_file = mmap.mmap(self.file.fileno(), 0, prot=mmap.PROT_READ)
         if summary_md is None:
             self.summary_md, self.first_ifd_offset = self._read_header()
         else:
@@ -323,6 +326,7 @@ class SingleNDTiffReader:
 
     def close(self):
         """ """
+        self.mmap_file.close()
         self.file.close()
 
     def _read_header(self):
@@ -364,8 +368,8 @@ class SingleNDTiffReader:
         """
         convert to python ints
         """
-        self.file.seek(int(start), 0)
-        return self.file.read(end - start)
+        self.mmap_file.seek(int(start), 0)
+        return self.mmap_file.read(end - start)
 
     def read_metadata(self, index):
         return json.loads(


### PR DESCRIPTION
Two things where changed here.
The first one, is that a new reader object is prevented and replaced by the ndtiff-writer-reader object. The presence of multiple reader objects did lead to some unstable, delayed behavior when images where read form a ndtiff-writer object.
The other is adding mmap to the ndtiff reader, this makes random access to the file much faster, when images are not read sequentially.